### PR TITLE
Added emacs-X11.exe to not_emacs_target

### DIFF
--- a/config.py
+++ b/config.py
@@ -134,6 +134,7 @@ def configure(keymap):
     not_emacs_target     = ["bash.exe",           # bash
                             "mintty.exe",         # mintty
                             "emacs.exe",          # Emacs
+                            "emacs-X11.exe",      # Emacs
                             "emacs-w32.exe",      # Emacs
                             "gvim.exe",           # GVim
                             "xyzzy.exe",          # xyzzy


### PR DESCRIPTION
Hi.
I am usig emacs on cygwin 2.9.0; its binary name is emacs-X11.exe and it is not in not_emacs_target. It would be very nice if you could add it to the list. I confirmed it worked.

Cordially yours,
Yoichi Hariguchi