### PR TITLE
Fakeymacs のバージョンをKeyhac のコンソールに出力する方が良い

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,6 +4,9 @@
 ##
 ## Windows の操作を Emacs のキーバインドで行うための設定（Keyhac版）ver.20200830_01
 ##
+fakeymacs_version = '''Fakeymacs ver.20200830_01
+  https://github.com/smzht/fakeymacs'''
+
 
 # このスクリプトは、Keyhac for Windows ver 1.82 以降で動作します。
 #   https://sites.google.com/site/craftware/keyhac-ja
@@ -2421,3 +2424,7 @@ def configure(keymap):
 
         # 個人設定ファイルのセクション [section-change_keyboard-2] を読み込んで実行する
         exec(read_config_personal("[section-change_keyboard-2]"), dict(globals(), **locals()))
+
+
+    print( fakeymacs_version )
+

--- a/config_light.py
+++ b/config_light.py
@@ -1776,3 +1776,6 @@ def configure(keymap):
 
     # 個人設定ファイルのセクション [section-base-2] を読み込んで実行する
     exec(read_config_personal("[section-base-2]"))
+
+    print( fakeymacs_version )
+

--- a/config_light.py
+++ b/config_light.py
@@ -4,6 +4,8 @@
 ##
 ## Windows の操作を Emacs のキーバインドで行うための設定 Light（Keyhac版）ver.20200829_01
 ##
+fakeymacs_version = '''Fakeymacs Light ver.20200829_01
+  https://github.com/smzht/fakeymacs'''
 
 # このスクリプトは、Keyhac for Windows ver 1.82 以降で動作します。
 #   https://sites.google.com/site/craftware/keyhac-ja


### PR DESCRIPTION
どのバージョンを使っているかわからなくなってしまうことが多いので。
こうしておくと、config.pyをlightからfullに切り替えてreloadした時にもわかりやすくなります。