### PR TITLE
WindowsTerminal が tsw として誤認識される問題を解消

### DIFF
--- a/config.py
+++ b/config.py
@@ -2189,6 +2189,9 @@ def configure(keymap):
     ###########################################################################
 
     def is_task_switching_window(window):
+        if window.getProcessName() not in ["explorer.exe"]:
+            return False
+
         if window.getClassName() in ["MultitaskingViewFrame",
                                      "TaskSwitcherWnd",
                                      "Windows.UI.Core.CoreWindow",


### PR DESCRIPTION
WindowsTerminal が tsw (タスク切り替え画面/タスクビュー) として誤認識されていました。
これを解決するのが本 PR の目的です。

現在、クラス名が `Windows.UI.Input.InputSite.WindowClass` のウィンドウは tsw として判定されますが、WindowsTerminal のクラス名がまさに `Windows.UI.Input.InputSite.WindowClass` であるため、誤って tsw と判定されてしまうようです。

タスク切り替え画面のプロセス名を見ると explorer.exe のようなので、判定基準に「プロセス名 = `explorer.exe`」を加えることで回避できました。(windows 10 上)

(windows 11 での動作は未確認です。不具合がある場合はお手数ですが取り下げをお願いします)