### PR TITLE
同時に有効になる複数のキーマップで、同じマルチストロークキーマップのキーを定義できないことを解決する

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@
 ## Windows の操作を Emacs のキーバインドで行うための設定（Keyhac版）
 ##
 
-fakeymacs_version = "20210925_01"
+fakeymacs_version = "20210930_01"
 
 # このスクリプトは、Keyhac for Windows ver 1.82 以降で動作します。
 #   https://sites.google.com/site/craftware/keyhac-ja
@@ -1429,6 +1429,15 @@ def configure(keymap):
 
     def define_key3(window_keymap, keys, command, check_func):
         define_key(window_keymap, keys, makeKeyCommand(window_keymap, keys, command, check_func))
+
+    def mergeMultiStrokeKeymap(window_keymap1, window_keymap2, keys):
+        for key_list in kbd(keys):
+            w_keymap1 = window_keymap1
+            w_keymap2 = window_keymap2
+            for key in key_list:
+                w_keymap1 = w_keymap1[key]
+                w_keymap2 = w_keymap2[key]
+            w_keymap1.keymap = {**w_keymap2.keymap, **w_keymap1.keymap}
 
     def getKeyCommand(window_keymap, keys):
         try:

--- a/fakeymacs_extensions/vscode_extensions/config.py
+++ b/fakeymacs_extensions/vscode_extensions/config.py
@@ -54,7 +54,7 @@ if fc.vscode_dired:
         vscodeExecuteCommand("Odb")()
         # vscodeExecuteCommand("extension.dired.open")()
 
-    define_key_v(keymap_emacs, "Ctl-x d",  reset_search(reset_undo(reset_counter(reset_mark(dired)))))
+    define_key(keymap_vscode, "Ctl-x d",  reset_search(reset_undo(reset_counter(reset_mark(dired)))))
 
 # --------------------------------------------------------------------------------------------------
 
@@ -74,7 +74,7 @@ if fc.vscode_occur:
         vscodeExecuteCommand("SiCF")()
         # vscodeExecuteCommand("search-in-current-file.searchInCurrentFile")()
 
-    define_key_v(keymap_emacs, "Ctl-x C-o", reset_search(reset_undo(reset_counter(reset_mark(occur)))))
+    define_key(keymap_vscode, "Ctl-x C-o", reset_search(reset_undo(reset_counter(reset_mark(occur)))))
 
 # --------------------------------------------------------------------------------------------------
 

--- a/fakeymacs_extensions/vscode_key/_config_personal.py
+++ b/fakeymacs_extensions/vscode_key/_config_personal.py
@@ -11,6 +11,6 @@ def toggle_panel():
     # vscodeExecuteCommand("workbench.action.togglePanel")()
 
 # 本設定を行わなくとも、C-q C-j を利用することで対応は可能
-define_key_v(keymap_emacs, "Ctl-x C-j", toggle_panel)
+define_key(keymap_vscode, "Ctl-x C-j", toggle_panel)
 
 # --------------------------------------------------------------------------------------------------

--- a/fakeymacs_extensions/vscode_key/config.py
+++ b/fakeymacs_extensions/vscode_key/config.py
@@ -390,11 +390,18 @@ define_key(keymap_vscode, "M-",     keymap.defineMultiStrokeKeymap("Esc"))
 define_key(keymap_vscode, "M-g",    keymap.defineMultiStrokeKeymap("M-g"))
 define_key(keymap_vscode, "M-g M-", keymap.defineMultiStrokeKeymap("M-g Esc"))
 
+fc.vscode_kemap_merged = False
+
+def mergeEmacsMultiStrokeKeymap():
+    if not fc.vscode_kemap_merged:
+        mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "Ctl-x")
+        mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-")
+        mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-g")
+        mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-g M-")
+        fc.vscode_kemap_merged = True
+
 ## keymap_emacs キーマップのマルチストロークキーの設定を keymap_vscode キーマップに複写する
-mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "Ctl-x")
-mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-")
-mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-g")
-mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-g M-")
+keymap_vscode.applying_func = mergeEmacsMultiStrokeKeymap
 
 ## プレフィックスキーの設定
 for pkey1, pkey2 in fc.vscode_prefix_key:

--- a/fakeymacs_extensions/vscode_key/config.py
+++ b/fakeymacs_extensions/vscode_key/config.py
@@ -390,15 +390,17 @@ define_key(keymap_vscode, "M-",     keymap.defineMultiStrokeKeymap("Esc"))
 define_key(keymap_vscode, "M-g",    keymap.defineMultiStrokeKeymap("M-g"))
 define_key(keymap_vscode, "M-g M-", keymap.defineMultiStrokeKeymap("M-g Esc"))
 
-fc.vscode_kemap_merged = False
+vscode_kemap_merged = False
 
 def mergeEmacsMultiStrokeKeymap():
-    if not fc.vscode_kemap_merged:
+    global vscode_kemap_merged
+
+    if not vscode_kemap_merged:
         mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "Ctl-x")
         mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-")
         mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-g")
         mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-g M-")
-        fc.vscode_kemap_merged = True
+        vscode_kemap_merged = True
 
 ## keymap_emacs キーマップのマルチストロークキーの設定を keymap_vscode キーマップに複写する
 keymap_vscode.applying_func = mergeEmacsMultiStrokeKeymap

--- a/fakeymacs_extensions/vscode_key/config.py
+++ b/fakeymacs_extensions/vscode_key/config.py
@@ -390,17 +390,15 @@ define_key(keymap_vscode, "M-",     keymap.defineMultiStrokeKeymap("Esc"))
 define_key(keymap_vscode, "M-g",    keymap.defineMultiStrokeKeymap("M-g"))
 define_key(keymap_vscode, "M-g M-", keymap.defineMultiStrokeKeymap("M-g Esc"))
 
-vscode_kemap_merged = False
+fakeymacs.vscode_keymap_merged = False
 
 def mergeEmacsMultiStrokeKeymap():
-    global vscode_kemap_merged
-
-    if not vscode_kemap_merged:
+    if not fakeymacs.vscode_keymap_merged:
         mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "Ctl-x")
         mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-")
         mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-g")
         mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-g M-")
-        vscode_kemap_merged = True
+        fakeymacs.vscode_keymap_merged = True
 
 ## keymap_emacs キーマップのマルチストロークキーの設定を keymap_vscode キーマップに複写する
 keymap_vscode.applying_func = mergeEmacsMultiStrokeKeymap

--- a/fakeymacs_extensions/vscode_key/config.py
+++ b/fakeymacs_extensions/vscode_key/config.py
@@ -69,9 +69,11 @@ def is_vscode_target(window):
         return False
 
 if fc.use_emacs_ime_mode:
-    fc.keymap_vscode = keymap_vscode = keymap.defineWindowKeymap(check_func=lambda wnd: is_vscode_target(wnd) and not is_emacs_ime_mode(wnd))
+    keymap_vscode = keymap.defineWindowKeymap(check_func=lambda wnd: is_vscode_target(wnd) and not is_emacs_ime_mode(wnd))
 else:
-    fc.keymap_vscode = keymap_vscode = keymap.defineWindowKeymap(check_func=is_vscode_target)
+    keymap_vscode = keymap.defineWindowKeymap(check_func=is_vscode_target)
+
+fc.keymap_vscode = keymap_vscode
 
 ## 共通関数
 def self_insert_command_v(*keys):
@@ -85,9 +87,6 @@ def self_insert_command_v(*keys):
         if ime_status:
             keymap.getWindow().setImeStatus(1)
     return _func
-
-def define_key_v(window_keymap, keys, command):
-    define_key3(window_keymap, keys, command, lambda: is_vscode_target(keymap.getWindow()))
 
 def vscodeExecuteCommand(command):
     def _func():
@@ -385,6 +384,18 @@ def trigger_suggest():
     self_insert_command("C-Space")()
     # vscodeExecuteCommand("editor.action.triggerSuggest")()
 
+## マルチストロークキーの設定
+define_key(keymap_vscode, "Ctl-x",  keymap.defineMultiStrokeKeymap(fc.ctl_x_prefix_key))
+define_key(keymap_vscode, "M-",     keymap.defineMultiStrokeKeymap("Esc"))
+define_key(keymap_vscode, "M-g",    keymap.defineMultiStrokeKeymap("M-g"))
+define_key(keymap_vscode, "M-g M-", keymap.defineMultiStrokeKeymap("M-g Esc"))
+
+## keymap_emacs キーマップのマルチストロークキーの設定を keymap_vscode キーマップに複写する
+mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "Ctl-x")
+mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-")
+mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-g")
+mergeMultiStrokeKeymap(keymap_vscode, keymap_emacs, "M-g M-")
+
 ## プレフィックスキーの設定
 for pkey1, pkey2 in fc.vscode_prefix_key:
     define_key(keymap_vscode, pkey2, keymap.defineMultiStrokeKeymap("<VSCode> " + pkey1))
@@ -398,20 +409,20 @@ for pkey1, pkey2 in fc.vscode_prefix_key:
                     define_key(keymap_vscode, "{} {}".format(pkey2, mkey), self_insert_command_v(pkey1, mkey))
 
 ## 「ファイル操作」のキー設定
-define_key_v(keymap_emacs, "Ctl-x C-d", reset_search(reset_undo(reset_counter(reset_mark(find_directory)))))
-define_key_v(keymap_emacs, "Ctl-x C-r", reset_search(reset_undo(reset_counter(reset_mark(recentf)))))
-define_key_v(keymap_emacs, "Ctl-x C-l", reset_search(reset_undo(reset_counter(reset_mark(locate)))))
+define_key(keymap_vscode, "Ctl-x C-d", reset_search(reset_undo(reset_counter(reset_mark(find_directory)))))
+define_key(keymap_vscode, "Ctl-x C-r", reset_search(reset_undo(reset_counter(reset_mark(recentf)))))
+define_key(keymap_vscode, "Ctl-x C-l", reset_search(reset_undo(reset_counter(reset_mark(locate)))))
 
 ## 「カーソル移動」のキー設定
-define_key_v(keymap_emacs, "M-g p",   reset_search(reset_undo(reset_counter(reset_mark(previous_error)))))
-define_key_v(keymap_emacs, "M-g M-p", reset_search(reset_undo(reset_counter(reset_mark(previous_error)))))
-define_key_v(keymap_emacs, "M-g n",   reset_search(reset_undo(reset_counter(reset_mark(next_error)))))
-define_key_v(keymap_emacs, "M-g M-n", reset_search(reset_undo(reset_counter(reset_mark(next_error)))))
+define_key(keymap_vscode, "M-g p",   reset_search(reset_undo(reset_counter(reset_mark(previous_error)))))
+define_key(keymap_vscode, "M-g M-p", reset_search(reset_undo(reset_counter(reset_mark(previous_error)))))
+define_key(keymap_vscode, "M-g n",   reset_search(reset_undo(reset_counter(reset_mark(next_error)))))
+define_key(keymap_vscode, "M-g M-n", reset_search(reset_undo(reset_counter(reset_mark(next_error)))))
 
 if is_japanese_keyboard:
-    define_key_v(keymap_emacs, "Ctl-x S-Atmark",  reset_search(reset_undo(reset_counter(reset_mark(next_error)))))
+    define_key(keymap_vscode, "Ctl-x S-Atmark",  reset_search(reset_undo(reset_counter(reset_mark(next_error)))))
 else:
-    define_key_v(keymap_emacs, "Ctl-x BackQuote", reset_search(reset_undo(reset_counter(reset_mark(next_error)))))
+    define_key(keymap_vscode, "Ctl-x BackQuote", reset_search(reset_undo(reset_counter(reset_mark(next_error)))))
 
 define_key(keymap_vscode, "A-p", self_insert_command("C-Up"))
 define_key(keymap_vscode, "A-n", self_insert_command("C-Down"))
@@ -421,21 +432,21 @@ define_key(keymap_vscode, "C-k", reset_search(reset_undo(reset_counter(reset_mar
 define_key(keymap_vscode, "C-y", reset_search(reset_undo(reset_counter(reset_mark(repeat(yank_v))))))
 
 ## 「バッファ / ウィンドウ操作」のキー設定
-define_key_v(keymap_emacs, "Ctl-x k",   reset_search(reset_undo(reset_counter(reset_mark(kill_buffer)))))
-define_key_v(keymap_emacs, "Ctl-x b",   reset_search(reset_undo(reset_counter(reset_mark(switch_to_buffer)))))
-define_key_v(keymap_emacs, "Ctl-x C-b", reset_search(reset_undo(reset_counter(reset_mark(list_buffers)))))
+define_key(keymap_vscode, "Ctl-x k",   reset_search(reset_undo(reset_counter(reset_mark(kill_buffer)))))
+define_key(keymap_vscode, "Ctl-x b",   reset_search(reset_undo(reset_counter(reset_mark(switch_to_buffer)))))
+define_key(keymap_vscode, "Ctl-x C-b", reset_search(reset_undo(reset_counter(reset_mark(list_buffers)))))
 
 ## 「文字列検索」のキー設定
 define_key(keymap_vscode, "C-r", reset_undo(reset_counter(reset_mark(isearch_backward))))
 define_key(keymap_vscode, "C-s", reset_undo(reset_counter(reset_mark(isearch_forward))))
 
 ## 「エディタ操作」のキー設定
-define_key_v(keymap_emacs, "Ctl-x 0", reset_search(reset_undo(reset_counter(reset_mark(delete_group)))))
-define_key_v(keymap_emacs, "Ctl-x 1", reset_search(reset_undo(reset_counter(reset_mark(delete_other_groups)))))
-define_key_v(keymap_emacs, "Ctl-x 2", split_editor_below)
-define_key_v(keymap_emacs, "Ctl-x 3", split_editor_right)
-define_key_v(keymap_emacs, "Ctl-x 4", rotate_layout)
-define_key_v(keymap_emacs, "Ctl-x o", reset_search(reset_undo(reset_counter(reset_mark(other_group)))))
+define_key(keymap_vscode, "Ctl-x 0", reset_search(reset_undo(reset_counter(reset_mark(delete_group)))))
+define_key(keymap_vscode, "Ctl-x 1", reset_search(reset_undo(reset_counter(reset_mark(delete_other_groups)))))
+define_key(keymap_vscode, "Ctl-x 2", split_editor_below)
+define_key(keymap_vscode, "Ctl-x 3", split_editor_right)
+define_key(keymap_vscode, "Ctl-x 4", rotate_layout)
+define_key(keymap_vscode, "Ctl-x o", reset_search(reset_undo(reset_counter(reset_mark(other_group)))))
 
 if fc.use_ctrl_digit_key_for_digit_argument:
     key = "C-A-{}"
@@ -479,12 +490,11 @@ else:
     define_key(keymap_vscode, "C-BackQuote",   reset_search(reset_undo(reset_counter(reset_mark(toggle_terminal)))))
 
 ## 「その他」のキー設定
-define_key(keymap_vscode, "Enter", post(reset_undo(reset_counter(reset_mark(repeat(newline))))))
-define_key(keymap_vscode, "C-m",   post(reset_undo(reset_counter(reset_mark(repeat(newline))))))
-define_key(keymap_vscode, "C-g",   reset_search(reset_counter(reset_mark(keyboard_quit_v2))))
-
-define_key_v(keymap_emacs, "M-x",         reset_search(reset_undo(reset_counter(reset_mark(execute_extended_command)))))
-define_key_v(keymap_emacs, "M-Semicolon", reset_search(reset_undo(reset_counter(reset_mark(comment_dwim)))))
+define_key(keymap_vscode, "Enter",       post(reset_undo(reset_counter(reset_mark(repeat(newline))))))
+define_key(keymap_vscode, "C-m",         post(reset_undo(reset_counter(reset_mark(repeat(newline))))))
+define_key(keymap_vscode, "C-g",         reset_search(reset_counter(reset_mark(keyboard_quit_v2))))
+define_key(keymap_vscode, "M-x",         reset_search(reset_undo(reset_counter(reset_mark(execute_extended_command)))))
+define_key(keymap_vscode, "M-Semicolon", reset_search(reset_undo(reset_counter(reset_mark(comment_dwim)))))
 
 if is_japanese_keyboard:
     define_key(keymap_vscode, "C-Colon", trigger_suggest)

--- a/fakeymacs_manuals/functions.org
+++ b/fakeymacs_manuals/functions.org
@@ -118,13 +118,13 @@ def mergeMultiStrokeKeymap(window_keymap1, window_keymap2, keys):
 
 **** Parameters
 
-|----------------+-------------------------------------|
-| Parameter      | Description                         |
-|----------------+-------------------------------------|
-| window_keymap1 | マージ先の WindowKeymapオブジェクト |
-| window_keymap2 | マージする WindowKeymapオブジェクト |
-| keys           | マージするマルチストロークのキー    |
-|----------------+-------------------------------------|
+|----------------+----------------------------------|
+| Parameter      | Description                      |
+|----------------+----------------------------------|
+| window_keymap1 | WindowKeymapオブジェクト1        |
+| window_keymap2 | WindowKeymapオブジェクト2        |
+| keys           | マージするマルチストロークのキー |
+|----------------+----------------------------------|
 
 **** Returns
 

--- a/fakeymacs_manuals/functions.org
+++ b/fakeymacs_manuals/functions.org
@@ -8,7 +8,7 @@
 
 *** ■ checkWindow
 
-ウィンドウが指定した条件に該当するかチェックする。
+ウィンドウが指定した条件に該当するかチェックする
 
 **** Function
 
@@ -34,7 +34,7 @@ def checkWindow(process_name, class_name, text, window=None):
 
 *** ■ define_key
 
-キーマップにキーを定義する。（skip_settings_key に定義したキーの設定を行わないバージョン）
+キーマップにキーを定義する（skip_settings_key に定義したキーの設定を行わないバージョン）
 
 **** Function
 
@@ -58,7 +58,7 @@ def define_key(window_keymap, keys, command):
 
 *** ■ define_key2
 
-キーマップにキーを定義する。（skip_settings_key に定義したキーであっても設定するバージョン）
+キーマップにキーを定義する（skip_settings_key に定義したキーであっても設定するバージョン）
 
 **** Function
 
@@ -82,7 +82,7 @@ def define_key2(window_keymap, keys, command):
 
 *** ■ define_key3
 
-キーマップにキーを定義する。（キーに定義されている関数に新しいコマンドを分岐実行させるバージョン）
+キーマップにキーを定義する（キーに定義されている関数に新しいコマンドを分岐実行させるバージョン）
 
 **** Function
 
@@ -105,9 +105,34 @@ def define_key3(window_keymap, keys, command, chek_func):
 
 - 無し
 
+*** ■ mergeMultiStrokeKeymap
+
+第2引数の WindowKeymapオブジェクトのキーマップにに第1引数の WindowKeymapオブジェクトの
+キーマップをマージ（上書き）し、第1引数の WindowKeymapオブジェクトのキーマップに設定する
+
+**** Function
+
+#+BEGIN_EXAMPLE
+def mergeMultiStrokeKeymap(window_keymap1, window_keymap2, keys):
+#+END_EXAMPLE
+
+**** Parameters
+
+|----------------+-------------------------------------|
+| Parameter      | Description                         |
+|----------------+-------------------------------------|
+| window_keymap1 | マージ先の WindowKeymapオブジェクト |
+| window_keymap2 | マージする WindowKeymapオブジェクト |
+| keys           | マージするマルチストロークのキー    |
+|----------------+-------------------------------------|
+
+**** Returns
+
+- 無し
+
 *** ■ getKeyCommand
 
-キーに定義されている関数を返す。
+キーに定義されている関数を返す
 
 **** Function
 
@@ -130,7 +155,7 @@ def getKeyCommand(window_keymap, keys):
 
 *** ■ makeKeyCommand
 
-キーに定義されている関数に新しいコマンドを分岐実行させる新たな関数を返す。
+キーに定義されている関数に新しいコマンドを分岐実行させる新たな関数を返す
 
 **** Function
 
@@ -155,7 +180,7 @@ def makeKeyCommand(window_keymap, keys, command, check_func):
 
 *** ■ self_insert_command
 
-キーを入力する関数を返す。
+キーを入力する関数を返す
 
 **** Function
 
@@ -178,7 +203,7 @@ def self_insert_command(*keys):
 *** ■ mark
 
 mark がセットされていれば、その mark から func で移動した場所までのリージョンを拡張する
-ための新たな関数を返す。
+ための新たな関数を返す
 
 **** Function
 
@@ -201,7 +226,7 @@ def mark(func, forward_direction):
 
 *** ■ mark2
 
-func で移動した場所までのリージョンを拡張するための新たな関数を返す。
+func で移動した場所までのリージョンを拡張するための新たな関数を返す
 （Shift を使ったリージョン拡張処理などで利用）
 
 **** Function
@@ -225,7 +250,7 @@ def mark2(func, forward_direction):
 
 *** ■ reset_mark
 
-mark の状態を reset する新たな関数を返す。
+mark の状態を reset する新たな関数を返す
 
 **** Function
 
@@ -247,7 +272,7 @@ def reset_mark(func):
 
 *** ■ reset_counter
 
-repeat counter の状態を reset する新たな関数を返す。
+repeat counter の状態を reset する新たな関数を返す
 
 **** Function
 
@@ -269,7 +294,7 @@ def reset_counter(func):
 
 *** ■ reset_undo
 
-undo/redo の状態を undo に reset する新たな関数を返す。
+undo/redo の状態を undo に reset する新たな関数を返す
 
 **** Function
 
@@ -291,7 +316,7 @@ def reset_undo(func):
 
 *** ■ reset_search
 
-検索中の状態を reset する新たな関数を返す。
+検索中の状態を reset する新たな関数を返す
 
 **** Function
 
@@ -313,7 +338,7 @@ def reset_search(func):
 
 *** ■ repeat
 
-数引数の値に従い、repeat の処理を施した新たな関数を返す。
+数引数の値に従い、repeat の処理を施した新たな関数を返す
 
 **** Function
 
@@ -335,7 +360,7 @@ def repeat(func):
 
 *** ■ repeat2
 
-数引数の値に従い、repeat の処理を施した新たな関数を返す。
+数引数の値に従い、repeat の処理を施した新たな関数を返す
 （リーションが設定してある場合は、一回のみ処理を行うバージョン）
 
 **** Function
@@ -358,7 +383,7 @@ def repeat2(func):
 
 *** ■ repeat3
 
-数引数の値に従い、repeat の処理を施した新たな関数を返す。
+数引数の値に従い、repeat の処理を施した新たな関数を返す
 （repaet 回数を func の引数で渡すバージョン）
 
 **** Function
@@ -381,7 +406,7 @@ def repeat3(func):
 
 *** ■ delay
 
-処理を指定した時間停止する。
+処理を指定した時間停止する
 
 **** Function
 


### PR DESCRIPTION
vscode_key Extension で定義している keymap_vscode は、Emacs キーバインド用の keymap_emacs を拡張する目的で作成しているため、vscode などを利用する際は、keymap_emacs と同時に有効となるキーマップとなっています。

ただし、Keyhac の仕様上、複数のキーマップで同じマルチストロークのキーマップのキーを定義することができないため、 keymap_emacs で定義しているマルチストロークのキーマップを keymap_vscode でも利用したい場合には、keymap_emacs 側のマルチストロークのキーマップにキーを定義し、そこから呼ばれるコマンド内で処理を分岐するなど、追加の対応が必要となります。また、性能的にも好ましい状況ではありません。

今回は、この問題をマルチストロークキーマップをマージして再設定することにより、解決を図ります。