### PR TITLE
VSCodeパネル内ターミナルを表示すると読み取り専用エディタになり入力できない問題を解消する

### DIFF
--- a/fakeymacs_extensions/vscode_key/config.py
+++ b/fakeymacs_extensions/vscode_key/config.py
@@ -432,7 +432,7 @@ def toggle_terminal():
     if fc.use_direct_input_in_vscode_terminal:
         if fakeymacs_vscode.vscode_focus == "not_terminal":
             # VSCode Command : Terminal: Focus on Terminal View
-            vscodeExecuteCommand2("terminal.focus")()
+            vscodeExecuteCommand2("terminal.focus", esc=True)()
 
             fakeymacs_vscode.vscode_focus = "terminal"
         else:


### PR DESCRIPTION
VSCode用キー設定を有効化、`fc.use_direct_input_in_vscode_terminal = True`に設定して利用させてもらっています。

いつのタイミングからか不明ですが、`C-@`を入力しパネル内ターミナルを表示すると読み取りになってしまうようになりました。
![image](https://github.com/smzht/fakeymacs/assets/511827/258eafab-8c77-443b-95f5-20c66881adfe)

`Esc`を入力すると読み取り専用から脱出できるので、`Esc`を発行するフラグを立てました。

### `C-@`入力時のKeyhacログ

```
IN  : D-LCtrl
OUT : [KeyUp(162), KeyDown(162), KeyDown(162)]
IN  : D-LC-Atmark
OUT : [KeyUp(162), Key(112), KeyDown(162)]
OUT : [KeyUp(162), Key(0), Key(0), Key(0), Key(0), Key(0), Key(0), Key(0), Key(0), Key(0), Key(0), Key(0), Key(0), Key(0), Key(0), KeyDown(162)]
OUT : [KeyUp(162), Key(13), KeyDown(162)]
IN  : U-LC-Atmark
TRU : U-LC-Atmark
IN  : O-LC-Atmark
IN  : U-LCtrl
TRU : U-LCtr
```

### 環境

Windows: 11 Pro バージョン 22H2 (OSビルド 22621.2134)
Keyhac: 1.82
Fakeymacs: 20230907_03
VSCode: 1.82.2